### PR TITLE
Fix wrong parentheses in timestamp calculation

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -72,7 +72,7 @@ pub fn tag_header(input: &[u8]) -> IResult<&[u8], TagHeader> {
   let header = TagHeader {
     tag_type,
     data_size,
-    timestamp: (timestamp_extended as u32) << (24 + timestamp),
+    timestamp: (u32::from(timestamp_extended) << 24) + timestamp,
     stream_id,
   };
   Ok((i, header))
@@ -95,7 +95,7 @@ pub fn complete_tag(input: &[u8]) -> IResult<&[u8], Tag<'_>> {
     header: TagHeader {
       tag_type,
       data_size,
-      timestamp: (timestamp_extended as u32) << (24 + timestamp),
+      timestamp: (u32::from(timestamp_extended) << 24) + timestamp,
       stream_id,
     },
     data,


### PR DESCRIPTION
Fixes a regression from the nom 7 upgrade

Fixes: #26 