### PR TITLE
Changed the heading to use 'an' instead of 'a'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Flavors, a FLV parser in Rust with nom
+# Flavors, an FLV parser in Rust with nom
 
 [![Actions Status](https://github.com/rust-av/flavors/workflows/flavors/badge.svg)](https://github.com/rust-av/flavors/actions)
 [![Coverage Status](https://coveralls.io/repos/Geal/flavors/badge.svg?branch=master)](https://coveralls.io/r/Geal/flavors?branch=master)


### PR DESCRIPTION
The choice of 'an' or 'a' is based on the phonetic (sound quality) of the first letter in a word and therefore 'an' seems appropriate to use before FLV.